### PR TITLE
Fix Rx reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # callbag-share
 
-Callbag operator that broadcasts a single source to multiple sinks. Does reference counting on sinks and starts the source when the first sink gets connected, similar to RxJS `.publish().refCount()`. Works on either pullable or listenable sources.
+Callbag operator that broadcasts a single source to multiple sinks. Does reference counting on sinks and starts the source when the first sink gets connected, similar to RxJS [`.share()`](https://www.learnrxjs.io/operators/multicasting/share.html). Works on either pullable or listenable sources.
 
 `npm install callbag-share`
 


### PR DESCRIPTION
This continues discussion from https://github.com/staltz/callbag-share/issues/5#event-1663650795

[`.publish().refCount()`](https://github.com/staltz/callbag-share/issues/5#issuecomment-394712689) seems to act slightly different than [`.share()`](https://github.com/staltz/callbag-share/issues/5#issuecomment-394730705), and this package behaves like the latter.