### PR TITLE
Distribute module entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /package-lock.json
 /shrinkwrap.yaml
+index.cjs.js

--- a/index.js
+++ b/index.js
@@ -30,6 +30,6 @@ const share = source => {
 
     sink(0, talkback);
   }
-}
+};
 
-module.exports = share;
+export default share;

--- a/package.json
+++ b/package.json
@@ -6,14 +6,21 @@
     "type": "git",
     "url": "git+https://github.com/staltz/callbag-share.git"
   },
-  "main": "index.js",
+  "main": "index.cjs.js",
+  "module": "index.js",
   "scripts": {
-    "test": "tape test.js"
+    "build": "rollup $npm_package_module -o $npm_package_main --f cjs",
+    "pretest": "npm run build",
+    "test": "tape test.js",
+    "prepare": "npm test"
   },
   "author": "staltz.com",
   "license": "MIT",
-  "keywords": ["callbag"],
+  "keywords": [
+    "callbag"
+  ],
   "devDependencies": {
+    "rollup": "^0.60.1",
     "tape": "^4.8.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const share = require('./index');
+const share = require('.');
 
 test('it shares an async finite listenable source', t => {
   t.plan(26);


### PR DESCRIPTION
This is a trial PR. Ideally I'd like to send similar PRs to all your callbag repositories.

Advantages?
- making it tree-shakeable when using reexporting packages (similar to `callbag-basics`, but i.e. we maintain our own package of callbags and import everything directly from it, instead of using direct imports)
- making scope hoisting aka module concatenation in webpack possible - webpack wraps each CJS lib with a runtime module closure, which costs around 17 bytes (each). Callbags aims to be super small, so I personally think that those 17 bytes are worth fighting for 😉 
- CJS files being now in strict mode, supposedly giving some engine benefits in node.js (not 100% sure about this though). This could ofc be added manually, but now `rollup` ensures directive being added when building CJS file